### PR TITLE
chore: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       prefix: "ci"
       include: "scope"
 
-  # Python dependencies - Minor & Patch updates (grouped)
+  # Python dependencies (uv) - Consolidated due to GitHub constraints
   - package-ecosystem: uv
     directory: /
     schedule:
@@ -26,11 +26,13 @@ updates:
     labels:
       - dependencies
       - type:build
-      - semver:patch
+      # Note: All updates get same labels due to GitHub constraint
+      # Major updates distinguishable by: individual PRs + commit messages
     commit-message:
       prefix: "chore"
       include: "scope"
     # Group minor and patch updates together to reduce PR noise
+    # Major updates will come as individual PRs (not grouped)
     groups:
       python-minor-patch:
         patterns:
@@ -42,47 +44,5 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
-    # Don't update git dependencies automatically (like streamlit-pydantic)
-    ignore:
-      - dependency-name: "streamlit-pydantic"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
-  # Python dependencies - Major updates (individual PRs)
-  - package-ecosystem: uv
-    directory: /
-    schedule:
-      interval: weekly
-      day: wednesday
-      time: "09:00"
-    labels:
-      - dependencies
-      - type:feat
-      - semver:major
-      - breaking-change
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    # Allow version updates for all dependencies
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
-    # Don't update git dependencies automatically (like streamlit-pydantic)
-    ignore:
-      - dependency-name: "streamlit-pydantic"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    
-  # Security updates - more frequent
-  - package-ecosystem: uv
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - dependencies
-      - security
-      - type:fix
-      - semver:patch
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    # Only security updates in this job
-    open-pull-requests-limit: 5
+    # Allow up to 10 open PRs (includes security updates which are prioritized)
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Fix Dependabot Configuration Error

### Problem
Dependabot was failing with error: "Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'uv' has overlapping directories."

The configuration had three separate `uv` package ecosystem entries all targeting the same directory `/`, which GitHub doesn't allow.

### Changes
- **Consolidated configurations**: Merged three overlapping `uv` configurations into a single one
- **Maintained core functionality**: 
  - Minor/patch updates are still grouped together to reduce PR noise
  - Major updates still come as individual PRs (not grouped)
  - Weekly schedule maintained (Tuesday 9am)
  - Security updates automatically prioritized by Dependabot
- **Cleaned up ignore rules**: Removed unnecessary ignore for `streamlit-pydantic` (not used in project)
- **Simplified labeling**: Uses `dependencies` + `type:build` for all Python dependency updates
